### PR TITLE
Set default input encoding to UTF8

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -12,6 +12,7 @@
 %%%%
 
 \documentclass [a4paper,12pt,twoside]{book}
+\usepackage[utf8]{inputenc}
 \usepackage[dutch,english]{babel}
 \usepackage{graphicx}
 \usepackage{natbib}


### PR DESCRIPTION
Hello Loïc,

I propose to set the default input encoding to UTF8. As this template will be used across many operating systems, it would be good to explicitly define an input encoding. This minimizes differences in compiling and the output. This is considered a best practice by most sources I could find, e.g. [LaTeX wiki on wikibooks](https://en.wikibooks.org/wiki/LaTeX/Special_Characters#A_technical_matter) and [the ShareLaTeX tutorials](https://www.sharelatex.com/learn/Creating_a_document_in_LaTeX#The_preamble_of_a_document). 

If you would like to know more about which OS uses what input encoding and the reason behind this best practice, I recommend reading the aforementioned wikibooks link. 
