### PR TITLE
change tabular specifiers on title pages

### DIFF
--- a/000_Title.tex
+++ b/000_Title.tex
@@ -13,7 +13,9 @@
 \newpage
 \thispagestyle{empty}
 \vspace*{\fill}
-\begin{tabular}{l}
+% @{} removes indentation completely from the first tabular column
+% p{\textwidth} formats the tabular environment as a paragraph, at the same width as regular text
+\begin{tabular}{@{}p{\textwidth}}
     \textbf{Thesis committee}                                                                 \\  
                                                                                               \\  
     \textbf{Promotor:}                                                                        \\  
@@ -33,9 +35,8 @@
     Prof.dr Jury member 3, Affiliation                                                        \\  
     Prof.dr Jury member 4, Affiliation                                                        \\  
                                                                                               \\  
-
-    \small{This research was conducted under the auspices of the C.T. de Wit Graduate School} \\  
-    \small{of Production Ecology \& Resource Conservation (PE$\&$RC)}                         \\  
+    \small{This research was conducted under the auspices of the C.T. de Wit Graduate School
+    of Production Ecology \& Resource Conservation (PE$\&$RC)}                                  
 \end{tabular}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -64,8 +65,7 @@ at 4 p.m. in the Aula.\\
 \newpage
 \thispagestyle{empty}
 \vspace*{\fill}
-\begin{flushleft}
-\begin{tabular}{l}
+\begin{tabular}{@{}p{\textwidth}}
     John Doe                                                 \\  
     Title of your thesis                                     \\  
     170 pages.                                               \\  
@@ -75,7 +75,6 @@ at 4 p.m. in the Aula.\\
                                                              \\  
     ISBN XXX-YYY                                             \\  
 \end{tabular}
-\end{flushleft}
 %\newpage
 %\thispagestyle{empty}
 %\begin{flushright}

--- a/000_Title.tex
+++ b/000_Title.tex
@@ -13,8 +13,10 @@
 \newpage
 \thispagestyle{empty}
 \vspace*{\fill}
-% @{} removes indentation completely from the first tabular column
+% \flushleft removes indentation from tabular
+% @{} removes column spacing in front of the first tabular column
 % p{\textwidth} formats the tabular environment as a paragraph, at the same width as regular text
+\begin{flushleft}
 \begin{tabular}{@{}p{\textwidth}}
     \textbf{Thesis committee}                                                                 \\  
                                                                                               \\  
@@ -38,6 +40,7 @@
     \small{This research was conducted under the auspices of the C.T. de Wit Graduate School
     of Production Ecology \& Resource Conservation (PE$\&$RC)}                                  
 \end{tabular}
+\end{flushleft}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \newpage
@@ -65,6 +68,7 @@ at 4 p.m. in the Aula.\\
 \newpage
 \thispagestyle{empty}
 \vspace*{\fill}
+\begin{flushleft}
 \begin{tabular}{@{}p{\textwidth}}
     John Doe                                                 \\  
     Title of your thesis                                     \\  
@@ -75,6 +79,7 @@ at 4 p.m. in the Aula.\\
                                                              \\  
     ISBN XXX-YYY                                             \\  
 \end{tabular}
+\end{flushleft}
 %\newpage
 %\thispagestyle{empty}
 %\begin{flushright}


### PR DESCRIPTION
With @{} removing indentation, the flushelfts are no longer needed. With the p{\textwidth} specifier, text is formatted in paragraph and manual line breaks within a long line (e.g. graduate school declaration) are no longer neccessary.